### PR TITLE
Fix run attempt errors

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :oracle_sqldeveloper, OracleSqldeveloper.Repo,
   database: "oracle_sqldeveloper.sqlite3",

--- a/lib/oracle_sqldeveloper_web/crud.ex
+++ b/lib/oracle_sqldeveloper_web/crud.ex
@@ -1,0 +1,16 @@
+defmodule OracleSqldeveloperWeb.Crud do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "cruds" do
+    field :name, :string
+    field :description, :string
+    timestamps()
+  end
+
+  def changeset(crud, attrs) do
+    crud
+    |> cast(attrs, [:name, :description])
+    |> validate_required([:name, :description])
+  end
+end

--- a/lib/oracle_sqldeveloper_web/gettext.ex
+++ b/lib/oracle_sqldeveloper_web/gettext.ex
@@ -1,0 +1,4 @@
+defmodule OracleSqldeveloperWeb.Gettext do
+  use Gettext.Backend, otp_app: :oracle_sqldeveloper
+  use Gettext, backend: OracleSqldeveloperWeb.Gettext
+end


### PR DESCRIPTION
Fixes #5

Fix deprecated `Mix.Config` usage and add missing `Crud` module.

* **config/config.exs**
  - Replace `use Mix.Config` with `import Config`.
  - Update `config` calls to use `Config` module.

* **lib/oracle_sqldeveloper_web/crud.ex**
  - Define `OracleSqldeveloperWeb.Crud` module.
  - Use `Ecto.Schema` and `import Ecto.Changeset`.
  - Define schema with `name` and `description` fields.
  - Define `changeset` function.

* **lib/oracle_sqldeveloper_web/gettext.ex**
  - Replace `use Gettext` with `use Gettext.Backend, otp_app: :oracle_sqldeveloper`.
  - Add `use Gettext, backend: OracleSqldeveloperWeb.Gettext`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/zlovtnik/oracle-sqldeveloper/pull/6?shareId=9f9fb23e-7515-4d31-9524-36b5fcecca58).